### PR TITLE
Added duplicated tests run hint.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -551,6 +551,32 @@ service.expects(:execute).returns(true)
 
 Choose only one to use – avoid mixing both approaches within one project.
 
+== Subclassing Test Cases
+
+Minitest uses Ruby classes, if a Minitest class inherits from another class, it will also inherit its methods 
+causing Minitest to run the parent's tests twice.
+
+[source,ruby]
+----
+# bad (unless multiple runs are the intended behavior)
+
+class ParentTest < Minitest::Test
+  def test_1
+    #... Run twice
+  end
+end
+
+class ChildTest < ParentTest
+  def test_2
+    #...
+  end
+end
+----
+
+In rare cases, we may want to run the tests twice, but in general avoid subclassing test cases.
+
+Note: The `minitest/spec` alternative syntax disable inheritance between test classes and so does not have this behavior.
+
 == Related Guides
 
 * https://rubystyle.guide[Ruby Style Guide]


### PR DESCRIPTION
Minitest uses Ruby classes, if a Minitest class inherits from another class, it will also inherit its methods causing Minitest to run the parent's tests twice. In some cases, we want them to run them twice, but most of the time, we don't.

This warning is based on a [Rubocop rule](https://github.com/rubocop/rubocop-minitest/pull/164) for duplicated tests. [This blog](https://ignaciochiazzo.medium.com/dont-run-your-ruby-minitest-classes-twice-988645662cdb) post and [this library](https://github.com/ignacio-chiazzo/ruby-minitest-analyzer) contain more information.

Fixes https://github.com/rubocop/minitest-style-guide/issues/45