### PR TITLE
Remove an incorrect example from `Refute Equal` rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,7 +112,6 @@ Use `refute_equal` if `expected` and `actual` should not be same.
 ----
 # bad
 assert("rubocop-minitest" != actual)
-assert(!"rubocop-minitest" == (actual))
 
 # good
 refute_equal("rubocop-minitest", actual)


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-minitest/issues/256.

This PR removes an incorrect example from `Refute Equal` rule.

`assert(!"rubocop-minitest" == (actual))` is not compatible with good case.